### PR TITLE
Create interactive chess dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# Snake Dashboard
+# Schach Dashboard
 
 Ein interaktives Dashboard mit Python-Backend und moderner Browser-Oberfläche,
-in dem du das klassische Snake spielen kannst. Der Highscore wird serverseitig
-verwaltet, während das Frontend Statistiken wie Score und Geschwindigkeit in
-Echtzeit aktualisiert.
+in dem du komplette Schachpartien direkt im Browser spielen kannst. Ergebnisse
+werden serverseitig gespeichert, während das Frontend dir den aktuellen
+Spielstand, den Zugverlauf und hilfreiche Aktionen präsentiert.
 
 ## Features
 
-- 🎮 Snake-Spiel im Canvas mit weicher Steuerung per Pfeiltasten oder WASD
-- 📈 Dashboard mit aktuellen Kennzahlen (Score, Highscore, Geschwindigkeit)
-- ☁️ Serverseitige Highscore-API auf Basis von Flask
-- 🧠 Pausenfunktion, Neustart-Schaltfläche und stetig steigende Geschwindigkeit
+- ♟️ Vollwertiges Schachbrett mit legalen Zügen inklusive Rochade,
+  en-passant und Umwandlungen
+- 📈 Dashboard mit Siegstatistik (Weiß, Schwarz, Remis) und dynamischem
+  Zugverlauf
+- ☁️ Serverseitige Ergebnis-API auf Basis von Flask
+- 🧠 Komfortfunktionen wie Aufgabe, Remisangebot und Neustart-Schaltfläche
 - 🎨 Dunkles, responsives UI-Design, optimiert für Desktop und Tablet
 
 ## Voraussetzungen
@@ -33,20 +35,20 @@ python app.py
 ```
 
 Die Anwendung ist anschließend unter <http://localhost:5000> erreichbar. Öffne
-die Seite im Browser, um das Spiel im Dashboard zu spielen.
+die Seite im Browser, um sofort loszuspielen.
 
 ## Steuerung
 
-- Pfeiltasten oder **WASD** zum Steuern der Schlange
-- **Leertaste** zum Pausieren bzw. Fortsetzen
-- **Neu starten**-Button auf dem Dashboard setzt das Spiel zurück
+- Klicke eine eigene Figur, um ihre legalen Züge hervorzuheben
+- Klicke ein Ziel-Feld, um den Zug auszuführen
+- Nutze die Aktionsbuttons für Aufgabe, Remis oder Neustart
 
 ## API-Endpunkte
 
-| Methode | Pfad             | Beschreibung                               |
-| ------- | ---------------- | ------------------------------------------ |
-| GET     | `/api/high-score` | Liefert den aktuell gespeicherten Highscore |
-| POST    | `/api/high-score` | Aktualisiert den Highscore mit einem Score  |
+| Methode | Pfad           | Beschreibung                                      |
+| ------- | -------------- | ------------------------------------------------- |
+| GET     | `/api/results` | Liefert die aggregierten Ergebnisse aller Partien |
+| POST    | `/api/results` | Aktualisiert die Statistik nach einer beendeten Partie |
 
-Die Highscore-Verwaltung ist in-memory umgesetzt und wird beim Neustart der
+Die Ergebnisverwaltung ist in-memory umgesetzt und wird beim Neustart der
 Anwendung zurückgesetzt.

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -28,7 +28,7 @@ body {
 }
 
 .app {
-  width: min(1100px, 100%);
+  width: min(1180px, 100%);
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -103,10 +103,11 @@ body {
   color: var(--accent);
 }
 
+
 .game {
   grid-area: game;
   position: relative;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.8), rgba(2, 6, 23, 0.92));
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(2, 6, 23, 0.9));
   border-radius: var(--radius-lg);
   border: 1px solid var(--panel-border);
   padding: 1.5rem;
@@ -116,37 +117,147 @@ body {
   box-shadow: var(--shadow);
 }
 
-#snake-board {
-  width: 100%;
-  max-width: 640px;
-  height: auto;
-  border-radius: 12px;
-  background: repeating-linear-gradient(
-      0deg,
-      rgba(15, 23, 42, 0.95),
-      rgba(15, 23, 42, 0.95) 20px,
-      rgba(30, 41, 59, 0.95) 20px,
-      rgba(30, 41, 59, 0.95) 40px
-    ),
-    radial-gradient(circle at top, rgba(148, 163, 184, 0.1), transparent 60%);
+.board-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.chess-board {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  grid-template-rows: repeat(8, minmax(0, 1fr));
+  width: min(520px, 80vw);
+  aspect-ratio: 1 / 1;
+  border-radius: 14px;
+  overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 0 25px rgba(15, 23, 42, 0.8);
+  box-shadow: inset 0 0 20px rgba(8, 15, 35, 0.65);
+}
+
+.square {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(2.4rem, 5vw, 3.1rem);
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+  border: none;
+  outline: none;
+}
+
+.square--light {
+  background: #cbd5f5;
+  color: #1e293b;
+}
+
+.square--dark {
+  background: #475569;
+  color: #f8fafc;
+}
+
+.square:focus-visible {
+  box-shadow: inset 0 0 0 4px rgba(56, 189, 248, 0.9);
+}
+
+.square--selected {
+  box-shadow: inset 0 0 0 4px rgba(56, 189, 248, 0.8);
+  transform: translateY(-2px);
+}
+
+.square--legal::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.8);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.square--capture::after {
+  width: 70%;
+  height: 70%;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.55);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.piece {
+  pointer-events: none;
+  text-shadow: 0 12px 35px rgba(8, 15, 35, 0.55);
 }
 
 .status-banner {
   position: absolute;
   left: 50%;
-  bottom: 1.5rem;
+  bottom: -3.5rem;
   transform: translateX(-50%);
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.9);
   color: var(--text);
-  padding: 0.75rem 1.5rem;
+  padding: 0.75rem 1.6rem;
   border-radius: 999px;
   border: 1px solid rgba(56, 189, 248, 0.4);
   backdrop-filter: blur(6px);
   box-shadow: 0 10px 25px rgba(8, 15, 35, 0.55);
   font-weight: 600;
   letter-spacing: 0.04em;
+}
+
+.promotion-dialog {
+  position: absolute;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  box-shadow: 0 18px 38px rgba(8, 15, 35, 0.55);
+  min-width: 220px;
+  text-align: center;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.promotion-dialog.active {
+  display: flex;
+}
+
+.promotion-dialog p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.promotion-options {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.promotion-options button {
+  padding: 0.65rem 0.5rem;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  background: rgba(56, 189, 248, 0.25);
+  color: var(--text);
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.promotion-options button:hover {
+  background: rgba(56, 189, 248, 0.4);
+  transform: translateY(-1px);
 }
 
 .sidebar {
@@ -182,6 +293,28 @@ body {
   line-height: 1.7;
 }
 
+.move-history {
+  margin: 0;
+  padding-left: 1.4rem;
+  max-height: 320px;
+  overflow-y: auto;
+  color: var(--text);
+  counter-reset: move;
+}
+
+.move-history li {
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+  background: rgba(56, 189, 248, 0.12);
+  padding: 0.4rem 0.6rem;
+  border-radius: 10px;
+}
+
+.button-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -198,6 +331,16 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.button--secondary {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.button--secondary:hover {
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.3);
 }
 
 .button:hover {
@@ -229,6 +372,12 @@ body {
 
   .panel {
     flex: 1 1 260px;
+  }
+
+  .status-banner {
+    position: static;
+    transform: none;
+    margin-top: 1rem;
   }
 }
 

--- a/static/js/chess.js
+++ b/static/js/chess.js
@@ -1,0 +1,806 @@
+const boardElement = document.getElementById("chess-board");
+const statusBanner = document.getElementById("status-banner");
+const moveHistoryElement = document.getElementById("move-history");
+const promotionDialog = document.getElementById("promotion-dialog");
+const promotionButtons = promotionDialog.querySelectorAll("button");
+const whiteWinsValue = document.getElementById("white-wins-value");
+const blackWinsValue = document.getElementById("black-wins-value");
+const drawsValue = document.getElementById("draws-value");
+const resetButton = document.getElementById("reset-button");
+const resignWhiteButton = document.getElementById("resign-white");
+const resignBlackButton = document.getElementById("resign-black");
+const offerDrawButton = document.getElementById("offer-draw");
+
+const statsEndpoint = "/api/results";
+
+const pieceSymbols = {
+  w: {
+    k: "\u2654",
+    q: "\u2655",
+    r: "\u2656",
+    b: "\u2657",
+    n: "\u2658",
+    p: "\u2659",
+  },
+  b: {
+    k: "\u265A",
+    q: "\u265B",
+    r: "\u265C",
+    b: "\u265D",
+    n: "\u265E",
+    p: "\u265F",
+  },
+};
+
+let boardState = [];
+let squareElements = [];
+let currentPlayer = "w";
+let selectedSquare = null;
+let legalMoves = [];
+let enPassantTarget = null;
+let pendingPromotion = null;
+let gameOver = false;
+let fullmoveNumber = 1;
+let moveHistory = [];
+
+const directions = {
+  rook: [
+    { row: -1, col: 0 },
+    { row: 1, col: 0 },
+    { row: 0, col: -1 },
+    { row: 0, col: 1 },
+  ],
+  bishop: [
+    { row: -1, col: -1 },
+    { row: -1, col: 1 },
+    { row: 1, col: -1 },
+    { row: 1, col: 1 },
+  ],
+};
+
+document.addEventListener("DOMContentLoaded", init);
+
+function init() {
+  setupBoardElements();
+  attachEventListeners();
+  resetGame();
+  fetchStats();
+}
+
+function attachEventListeners() {
+  resetButton.addEventListener("click", resetGame);
+  resignWhiteButton.addEventListener("click", () => handleResignation("white"));
+  resignBlackButton.addEventListener("click", () => handleResignation("black"));
+  offerDrawButton.addEventListener("click", handleDrawOffer);
+
+  promotionButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      if (!pendingPromotion) return;
+      const promotionType = button.dataset.piece;
+      pendingPromotion.move.promotion = promotionType;
+      promotionDialog.classList.remove("active");
+      completeMove(pendingPromotion.from, pendingPromotion.move);
+      pendingPromotion = null;
+    });
+  });
+}
+
+function setupBoardElements() {
+  boardElement.innerHTML = "";
+  squareElements = [];
+
+  for (let row = 0; row < 8; row += 1) {
+    const rowElements = [];
+    for (let col = 0; col < 8; col += 1) {
+      const square = document.createElement("button");
+      square.type = "button";
+      square.className = `square ${(row + col) % 2 === 0 ? "square--light" : "square--dark"}`;
+      square.dataset.row = row;
+      square.dataset.col = col;
+      square.setAttribute("aria-label", `Feld ${notationFromCoords(row, col)}`);
+      square.addEventListener("click", handleSquareClick);
+      boardElement.appendChild(square);
+      rowElements.push(square);
+    }
+    squareElements.push(rowElements);
+  }
+}
+
+function resetGame() {
+  boardState = createInitialBoard();
+  currentPlayer = "w";
+  selectedSquare = null;
+  legalMoves = [];
+  enPassantTarget = null;
+  pendingPromotion = null;
+  gameOver = false;
+  fullmoveNumber = 1;
+  moveHistory = [];
+  clearHighlights();
+  renderBoard();
+  renderMoveHistory();
+  updateStatus("Weiß am Zug");
+  promotionDialog.classList.remove("active");
+}
+
+function createInitialBoard() {
+  const layout = [
+    ["br", "bn", "bb", "bq", "bk", "bb", "bn", "br"],
+    ["bp", "bp", "bp", "bp", "bp", "bp", "bp", "bp"],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    [null, null, null, null, null, null, null, null],
+    ["wp", "wp", "wp", "wp", "wp", "wp", "wp", "wp"],
+    ["wr", "wn", "wb", "wq", "wk", "wb", "wn", "wr"],
+  ];
+
+  return layout.map((row) =>
+    row.map((code) => (code ? createPiece(code[0], code[1]) : null))
+  );
+}
+
+function createPiece(color, type) {
+  return { color, type, hasMoved: false };
+}
+
+function handleSquareClick(event) {
+  if (gameOver) {
+    return;
+  }
+
+  if (pendingPromotion) {
+    return;
+  }
+
+  const { row, col } = event.currentTarget.dataset;
+  const r = Number(row);
+  const c = Number(col);
+  const piece = boardState[r][c];
+
+  if (selectedSquare) {
+    if (selectedSquare.row === r && selectedSquare.col === c) {
+      clearSelection();
+      return;
+    }
+
+    const foundMove = legalMoves.find((move) => move.row === r && move.col === c);
+    if (!foundMove) {
+      if (piece && piece.color === currentPlayer) {
+        selectSquare(r, c);
+      } else {
+        clearSelection();
+      }
+      return;
+    }
+
+    if (foundMove.requiresPromotion) {
+      pendingPromotion = { from: { row: selectedSquare.row, col: selectedSquare.col }, move: foundMove };
+      showPromotionDialog(pieceAt(selectedSquare));
+      return;
+    }
+
+    completeMove({ row: selectedSquare.row, col: selectedSquare.col }, foundMove);
+    return;
+  }
+
+  if (piece && piece.color === currentPlayer) {
+    selectSquare(r, c);
+  }
+}
+
+function pieceAt(position) {
+  return boardState[position.row][position.col];
+}
+
+function selectSquare(row, col) {
+  selectedSquare = { row, col };
+  legalMoves = getLegalMoves(row, col);
+  clearHighlights();
+  squareElements[row][col].classList.add("square--selected");
+  legalMoves.forEach((move) => {
+    const square = squareElements[move.row][move.col];
+    square.classList.add("square--legal");
+    if (move.captures) {
+      square.classList.add("square--capture");
+    }
+  });
+}
+
+function clearSelection() {
+  selectedSquare = null;
+  legalMoves = [];
+  clearHighlights();
+}
+
+function clearHighlights() {
+  squareElements.flat().forEach((square) => {
+    square.classList.remove("square--selected", "square--legal", "square--capture");
+  });
+}
+
+function getLegalMoves(row, col) {
+  const piece = boardState[row][col];
+  if (!piece || piece.color !== currentPlayer) {
+    return [];
+  }
+
+  const pseudoMoves = generatePseudoLegalMoves(row, col, piece);
+  const legal = [];
+
+  pseudoMoves.forEach((move) => {
+    const simulatedBoard = applyMove(cloneBoard(boardState), { row, col }, move);
+    if (!isKingInCheck(simulatedBoard, currentPlayer)) {
+      legal.push(move);
+    }
+  });
+
+  return legal;
+}
+
+function generatePseudoLegalMoves(row, col, piece) {
+  const moves = [];
+  if (piece.type === "p") {
+    generatePawnMoves(row, col, piece, moves);
+  } else if (piece.type === "n") {
+    generateKnightMoves(row, col, piece, moves);
+  } else if (piece.type === "b") {
+    generateSlidingMoves(row, col, piece, directions.bishop, moves);
+  } else if (piece.type === "r") {
+    generateSlidingMoves(row, col, piece, directions.rook, moves);
+  } else if (piece.type === "q") {
+    generateSlidingMoves(row, col, piece, directions.rook.concat(directions.bishop), moves);
+  } else if (piece.type === "k") {
+    generateKingMoves(row, col, piece, moves);
+  }
+  return moves;
+}
+
+function generatePawnMoves(row, col, piece, moves) {
+  const direction = piece.color === "w" ? -1 : 1;
+  const startRow = piece.color === "w" ? 6 : 1;
+  const promotionRow = piece.color === "w" ? 0 : 7;
+
+  const oneAhead = { row: row + direction, col };
+  if (isOnBoard(oneAhead.row, oneAhead.col) && !boardState[oneAhead.row][oneAhead.col]) {
+    const move = createMove(oneAhead.row, oneAhead.col);
+    if (oneAhead.row === promotionRow) {
+      move.requiresPromotion = true;
+    }
+    moves.push(move);
+
+    if (row === startRow) {
+      const twoAhead = { row: row + 2 * direction, col };
+      if (isOnBoard(twoAhead.row, twoAhead.col) && !boardState[twoAhead.row][twoAhead.col]) {
+        moves.push({
+          row: twoAhead.row,
+          col: twoAhead.col,
+          doubleStep: true,
+        });
+      }
+    }
+  }
+
+  [-1, 1].forEach((colOffset) => {
+    const target = { row: row + direction, col: col + colOffset };
+    if (!isOnBoard(target.row, target.col)) return;
+
+    const targetPiece = boardState[target.row][target.col];
+    if (targetPiece && targetPiece.color !== piece.color) {
+      const captureMove = createMove(target.row, target.col, true);
+      if (target.row === promotionRow) {
+        captureMove.requiresPromotion = true;
+      }
+      moves.push(captureMove);
+    }
+  });
+
+  if (enPassantTarget && enPassantTarget.color !== piece.color) {
+    if (enPassantTarget.row === row && Math.abs(enPassantTarget.col - col) === 1) {
+      moves.push({
+        row: row + direction,
+        col: enPassantTarget.col,
+        enPassant: true,
+        captures: true,
+      });
+    }
+  }
+}
+
+function generateKnightMoves(row, col, piece, moves) {
+  const offsets = [
+    { row: -2, col: -1 },
+    { row: -2, col: 1 },
+    { row: -1, col: -2 },
+    { row: -1, col: 2 },
+    { row: 1, col: -2 },
+    { row: 1, col: 2 },
+    { row: 2, col: -1 },
+    { row: 2, col: 1 },
+  ];
+
+  offsets.forEach((offset) => {
+    const targetRow = row + offset.row;
+    const targetCol = col + offset.col;
+    if (!isOnBoard(targetRow, targetCol)) return;
+
+    const targetPiece = boardState[targetRow][targetCol];
+    if (!targetPiece || targetPiece.color !== piece.color) {
+      moves.push(createMove(targetRow, targetCol, Boolean(targetPiece)));
+    }
+  });
+}
+
+function generateSlidingMoves(row, col, piece, dirs, moves) {
+  dirs.forEach((dir) => {
+    let step = 1;
+    while (true) {
+      const targetRow = row + dir.row * step;
+      const targetCol = col + dir.col * step;
+      if (!isOnBoard(targetRow, targetCol)) break;
+
+      const targetPiece = boardState[targetRow][targetCol];
+      if (!targetPiece) {
+        moves.push(createMove(targetRow, targetCol));
+      } else {
+        if (targetPiece.color !== piece.color) {
+          moves.push(createMove(targetRow, targetCol, true));
+        }
+        break;
+      }
+      step += 1;
+    }
+  });
+}
+
+function generateKingMoves(row, col, piece, moves) {
+  for (let r = -1; r <= 1; r += 1) {
+    for (let c = -1; c <= 1; c += 1) {
+      if (r === 0 && c === 0) continue;
+      const targetRow = row + r;
+      const targetCol = col + c;
+      if (!isOnBoard(targetRow, targetCol)) continue;
+      const targetPiece = boardState[targetRow][targetCol];
+      if (!targetPiece || targetPiece.color !== piece.color) {
+        moves.push(createMove(targetRow, targetCol, Boolean(targetPiece)));
+      }
+    }
+  }
+
+  if (!piece.hasMoved && !isKingInCheck(boardState, piece.color)) {
+    tryAddCastleMove(row, col, piece, moves, true);
+    tryAddCastleMove(row, col, piece, moves, false);
+  }
+}
+
+function tryAddCastleMove(row, col, kingPiece, moves, kingSide) {
+  const rookCol = kingSide ? 7 : 0;
+  const step = kingSide ? 1 : -1;
+  const spaces = kingSide ? [5, 6] : [1, 2, 3];
+  const rook = boardState[row][rookCol];
+  if (!rook || rook.type !== "r" || rook.color !== kingPiece.color || rook.hasMoved) {
+    return;
+  }
+
+  const pathClear = spaces.every((c) => !boardState[row][c]);
+  if (!pathClear) {
+    return;
+  }
+
+  const squaresToCheck = kingSide ? [col, col + step, col + 2 * step] : [col, col + step, col + 2 * step];
+  const enemy = kingPiece.color === "w" ? "b" : "w";
+  const safe = squaresToCheck.every((c) => !isSquareAttacked(boardState, row, c, enemy));
+  if (!safe) {
+    return;
+  }
+
+  moves.push({
+    row,
+    col: col + 2 * step,
+    castle: kingSide ? "kingside" : "queenside",
+  });
+}
+
+function createMove(row, col, captures = false) {
+  return { row, col, captures };
+}
+
+function applyMove(board, from, move) {
+  const newBoard = board;
+  const piece = clonePiece(newBoard[from.row][from.col]);
+  newBoard[from.row][from.col] = null;
+  let newEnPassant = null;
+
+  if (piece.type === "p") {
+    if (move.enPassant) {
+      const direction = piece.color === "w" ? -1 : 1;
+      newBoard[from.row][move.col] = null;
+    }
+    if (move.doubleStep) {
+      newEnPassant = { row: move.row, col: move.col, color: piece.color };
+    }
+    if (move.promotion) {
+      piece.type = move.promotion;
+    }
+  }
+
+  if (move.castle) {
+    const row = from.row;
+    if (move.castle === "kingside") {
+      const rook = clonePiece(newBoard[row][7]);
+      newBoard[row][7] = null;
+      newBoard[row][5] = rook;
+      if (rook) rook.hasMoved = true;
+    } else {
+      const rook = clonePiece(newBoard[row][0]);
+      newBoard[row][0] = null;
+      newBoard[row][3] = rook;
+      if (rook) rook.hasMoved = true;
+    }
+  }
+
+  piece.hasMoved = true;
+  newBoard[move.row][move.col] = piece;
+  newBoard.enPassantTarget = newEnPassant;
+  return newBoard;
+}
+
+function completeMove(from, move) {
+  pendingPromotion = null;
+  promotionDialog.classList.remove("active");
+  const piece = boardState[from.row][from.col];
+  const enemyColor = currentPlayer === "w" ? "b" : "w";
+  const captures = move.captures || move.enPassant;
+
+  boardState = applyMove(cloneBoard(boardState), from, move);
+  enPassantTarget = boardState.enPassantTarget || null;
+  delete boardState.enPassantTarget;
+
+  const opponentInCheck = isKingInCheck(boardState, enemyColor);
+  const opponentHasMoves = playerHasMoves(boardState, enemyColor);
+  const isMate = opponentInCheck && !opponentHasMoves;
+  const isStalemate = !opponentInCheck && !opponentHasMoves;
+
+  const notation = buildNotation(
+    piece,
+    from,
+    move,
+    captures,
+    isMate,
+    opponentInCheck && !isMate
+  );
+  registerMove(notation, captures, piece.color);
+
+  currentPlayer = enemyColor;
+  selectedSquare = null;
+  legalMoves = [];
+  clearHighlights();
+  renderBoard();
+
+  if (isMate) {
+    const winner = piece.color === "w" ? "white" : "black";
+    updateStatus(`Schachmatt! ${piece.color === "w" ? "Weiß" : "Schwarz"} gewinnt.`);
+    gameOver = true;
+    submitResult(winner);
+  } else if (isStalemate) {
+    updateStatus("Patt! Unentschieden.");
+    gameOver = true;
+    submitResult("draw");
+  } else {
+    updateStatus(`${currentPlayer === "w" ? "Weiß" : "Schwarz"} am Zug${
+      opponentInCheck ? " – Schach!" : ""
+    }`);
+  }
+}
+
+function buildNotation(piece, from, move, captures, mate, check) {
+  let notation = "";
+  const pieceLetter = piece.type === "p" ? "" : piece.type.toUpperCase();
+  if (move.castle === "kingside") {
+    notation = "O-O";
+  } else if (move.castle === "queenside") {
+    notation = "O-O-O";
+  } else {
+    if (piece.type !== "p") {
+      notation += pieceLetter;
+    } else if (captures) {
+      notation += notationFromCoords(from.row, from.col)[0];
+    }
+    if (captures) {
+      notation += "x";
+    }
+    notation += notationFromCoords(move.row, move.col);
+    if (move.promotion) {
+      notation += `=${move.promotion.toUpperCase()}`;
+    }
+  }
+  if (mate) {
+    notation += "#";
+  } else if (check) {
+    notation += "+";
+  }
+  return notation;
+}
+
+function registerMove(notation, capture, color) {
+  if (color === "w") {
+    moveHistory.push({ move: fullmoveNumber, white: notation, black: "" });
+  } else {
+    const lastEntry = moveHistory[moveHistory.length - 1];
+    if (lastEntry) {
+      lastEntry.black = notation;
+    }
+    fullmoveNumber += 1;
+  }
+  renderMoveHistory();
+}
+
+function renderMoveHistory() {
+  moveHistoryElement.innerHTML = "";
+  moveHistory.forEach((entry) => {
+    const li = document.createElement("li");
+    li.textContent = `${entry.move}. ${entry.white}${entry.black ? `  … ${entry.black}` : ""}`;
+    moveHistoryElement.appendChild(li);
+  });
+  moveHistoryElement.scrollTop = moveHistoryElement.scrollHeight;
+}
+
+function renderBoard() {
+  for (let row = 0; row < 8; row += 1) {
+    for (let col = 0; col < 8; col += 1) {
+      const square = squareElements[row][col];
+      square.innerHTML = "";
+      const piece = boardState[row][col];
+      if (piece) {
+        const span = document.createElement("span");
+        span.className = "piece";
+        span.textContent = pieceSymbols[piece.color][piece.type];
+        span.setAttribute(
+          "aria-label",
+          `${piece.color === "w" ? "Weiße" : "Schwarze"} ${pieceName(piece.type)}`
+        );
+        square.appendChild(span);
+      }
+    }
+  }
+}
+
+function pieceName(type) {
+  switch (type) {
+    case "p":
+      return "Bauer";
+    case "n":
+      return "Springer";
+    case "b":
+      return "Läufer";
+    case "r":
+      return "Turm";
+    case "q":
+      return "Dame";
+    case "k":
+      return "König";
+    default:
+      return "Figur";
+  }
+}
+
+function isOnBoard(row, col) {
+  return row >= 0 && row < 8 && col >= 0 && col < 8;
+}
+
+function cloneBoard(board) {
+  return board.map((row) => row.map((piece) => clonePiece(piece)));
+}
+
+function clonePiece(piece) {
+  return piece ? { ...piece } : null;
+}
+
+function isKingInCheck(board, color) {
+  const kingPosition = findKing(board, color);
+  if (!kingPosition) return false;
+  const enemy = color === "w" ? "b" : "w";
+  return isSquareAttacked(board, kingPosition.row, kingPosition.col, enemy);
+}
+
+function findKing(board, color) {
+  for (let row = 0; row < 8; row += 1) {
+    for (let col = 0; col < 8; col += 1) {
+      const piece = board[row][col];
+      if (piece && piece.type === "k" && piece.color === color) {
+        return { row, col };
+      }
+    }
+  }
+  return null;
+}
+
+function isSquareAttacked(board, row, col, attackerColor) {
+  const pawnDirection = attackerColor === "w" ? -1 : 1;
+  const pawnRow = row + pawnDirection;
+  if (isOnBoard(pawnRow, col - 1)) {
+    const piece = board[pawnRow][col - 1];
+    if (piece && piece.color === attackerColor && piece.type === "p") {
+      return true;
+    }
+  }
+  if (isOnBoard(pawnRow, col + 1)) {
+    const piece = board[pawnRow][col + 1];
+    if (piece && piece.color === attackerColor && piece.type === "p") {
+      return true;
+    }
+  }
+
+  const knightOffsets = [
+    { row: -2, col: -1 },
+    { row: -2, col: 1 },
+    { row: -1, col: -2 },
+    { row: -1, col: 2 },
+    { row: 1, col: -2 },
+    { row: 1, col: 2 },
+    { row: 2, col: -1 },
+    { row: 2, col: 1 },
+  ];
+  if (
+    knightOffsets.some(({ row: r, col: c }) => {
+      const nr = row + r;
+      const nc = col + c;
+      if (!isOnBoard(nr, nc)) return false;
+      const piece = board[nr][nc];
+      return piece && piece.color === attackerColor && piece.type === "n";
+    })
+  ) {
+    return true;
+  }
+
+  const rookDirs = directions.rook;
+  if (isAttackedInDirections(board, row, col, attackerColor, rookDirs, ["r", "q"])) {
+    return true;
+  }
+
+  const bishopDirs = directions.bishop;
+  if (isAttackedInDirections(board, row, col, attackerColor, bishopDirs, ["b", "q"])) {
+    return true;
+  }
+
+  for (let r = -1; r <= 1; r += 1) {
+    for (let c = -1; c <= 1; c += 1) {
+      if (r === 0 && c === 0) continue;
+      const nr = row + r;
+      const nc = col + c;
+      if (!isOnBoard(nr, nc)) continue;
+      const piece = board[nr][nc];
+      if (piece && piece.color === attackerColor && piece.type === "k") {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isAttackedInDirections(board, row, col, attackerColor, dirs, validTypes) {
+  return dirs.some((dir) => {
+    let step = 1;
+    while (true) {
+      const nr = row + dir.row * step;
+      const nc = col + dir.col * step;
+      if (!isOnBoard(nr, nc)) return false;
+      const piece = board[nr][nc];
+      if (!piece) {
+        step += 1;
+        continue;
+      }
+      if (piece.color !== attackerColor) {
+        return false;
+      }
+      return validTypes.includes(piece.type);
+    }
+  });
+}
+
+function playerHasMoves(board, color) {
+  for (let row = 0; row < 8; row += 1) {
+    for (let col = 0; col < 8; col += 1) {
+      const piece = board[row][col];
+      if (piece && piece.color === color) {
+        const pseudoMoves = generatePseudoLegalMoves(row, col, piece);
+        for (let i = 0; i < pseudoMoves.length; i += 1) {
+          const simulatedBoard = applyMove(cloneBoard(board), { row, col }, pseudoMoves[i]);
+          if (!isKingInCheck(simulatedBoard, color)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function updateStatus(message) {
+  statusBanner.textContent = message;
+}
+
+function notationFromCoords(row, col) {
+  return "abcdefgh"[col] + (8 - row);
+}
+
+function showPromotionDialog(piece) {
+  promotionDialog.classList.add("active");
+  const color = piece.color;
+  promotionButtons.forEach((button) => {
+    const type = button.dataset.piece;
+    const symbol = pieceSymbols[color][type];
+    button.textContent = `${symbol} ${promotionLabel(type)}`;
+  });
+}
+
+function promotionLabel(type) {
+  switch (type) {
+    case "q":
+      return "Dame";
+    case "r":
+      return "Turm";
+    case "b":
+      return "Läufer";
+    case "n":
+      return "Springer";
+    default:
+      return "Figur";
+  }
+}
+
+function handleResignation(color) {
+  if (gameOver) return;
+  gameOver = true;
+  clearSelection();
+  promotionDialog.classList.remove("active");
+  pendingPromotion = null;
+  const winner = color === "white" ? "black" : "white";
+  updateStatus(`${color === "white" ? "Weiß" : "Schwarz"} gibt auf – ${
+    winner === "white" ? "Weiß" : "Schwarz"
+  } gewinnt.`);
+  submitResult(winner);
+}
+
+function handleDrawOffer() {
+  if (gameOver) return;
+  gameOver = true;
+  clearSelection();
+  promotionDialog.classList.remove("active");
+  pendingPromotion = null;
+  updateStatus("Die Partie endet remis.");
+  submitResult("draw");
+}
+
+function fetchStats() {
+  fetch(statsEndpoint)
+    .then((response) => response.json())
+    .then((data) => updateStatsUI(data))
+    .catch((error) => console.error("Fehler beim Laden der Statistik", error));
+}
+
+function submitResult(result) {
+  fetch(statsEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ result }),
+  })
+    .then((response) => response.json())
+    .then((data) => updateStatsUI(data))
+    .catch((error) => console.error("Fehler beim Aktualisieren der Statistik", error));
+}
+
+function updateStatsUI(stats) {
+  if (!stats) return;
+  if (typeof stats.whiteWins === "number") {
+    whiteWinsValue.textContent = stats.whiteWins;
+  }
+  if (typeof stats.blackWins === "number") {
+    blackWinsValue.textContent = stats.blackWins;
+  }
+  if (typeof stats.draws === "number") {
+    drawsValue.textContent = stats.draws;
+  }
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Snake Dashboard</title>
+    <title>Schach Dashboard</title>
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/dashboard.css') }}"
@@ -13,11 +13,11 @@
     <div class="app">
       <header class="app__header">
         <div>
-          <h1>Snake Dashboard</h1>
+          <h1>Schach Dashboard</h1>
           <p>
-            Spiele eine Runde Snake direkt im Browser. Sammle so viele Früchte
-            wie möglich und beobachte, wie sich dein Score in Echtzeit im
-            Dashboard aktualisiert.
+            Spiele spannende Partien Schach direkt im Browser. Wechsle dich
+            mit einer zweiten Person ab, analysiere deine Züge im Verlauf und
+            behalte die Siegstatistik stets im Blick.
           </p>
         </div>
       </header>
@@ -25,56 +25,75 @@
       <main class="dashboard">
         <section class="metrics" aria-label="Spielstatistiken">
           <article class="metric-card">
-            <h2>Aktueller Score</h2>
-            <p id="score-value" class="metric-card__value">0</p>
+            <h2>Siege Weiß</h2>
+            <p id="white-wins-value" class="metric-card__value">0</p>
           </article>
           <article class="metric-card">
-            <h2>Highscore (Server)</h2>
-            <p id="high-score-value" class="metric-card__value">0</p>
+            <h2>Siege Schwarz</h2>
+            <p id="black-wins-value" class="metric-card__value">0</p>
           </article>
           <article class="metric-card">
-            <h2>Geschwindigkeit</h2>
-            <p id="speed-value" class="metric-card__value">0</p>
+            <h2>Remis</h2>
+            <p id="draws-value" class="metric-card__value">0</p>
           </article>
         </section>
 
-        <section class="game" aria-label="Snake Spielbereich">
-          <canvas
-            id="snake-board"
-            width="640"
-            height="480"
-            role="img"
-            aria-label="Spielfeld für Snake"
-          ></canvas>
-          <div id="status-banner" class="status-banner" role="status">
-            Bereit zum Start
+        <section class="game" aria-label="Schachbrett">
+          <div class="board-wrapper">
+            <div
+              id="chess-board"
+              class="chess-board"
+              role="img"
+              aria-label="Schachbrett"
+            ></div>
+            <div id="status-banner" class="status-banner" role="status">
+              Weiß am Zug
+            </div>
+            <div id="promotion-dialog" class="promotion-dialog" role="dialog">
+              <p>Figur wählen:</p>
+              <div class="promotion-options">
+                <button data-piece="q" type="button">Dame</button>
+                <button data-piece="r" type="button">Turm</button>
+                <button data-piece="b" type="button">Läufer</button>
+                <button data-piece="n" type="button">Springer</button>
+              </div>
+            </div>
           </div>
         </section>
 
         <aside class="sidebar" aria-label="Bedienung und Hinweise">
           <section class="panel">
-            <h2>Steuerung</h2>
-            <ul>
-              <li>Pfeiltasten oder WASD zum Steuern der Schlange.</li>
-              <li>Drücke die Leertaste, um das Spiel zu pausieren oder fortzusetzen.</li>
-              <li>Nutze den Neu-Start Knopf, um jederzeit von vorne zu beginnen.</li>
-            </ul>
+            <h2>Zugverlauf</h2>
+            <ol id="move-history" class="move-history" aria-live="polite"></ol>
           </section>
           <section class="panel">
-            <h2>Spielverlauf</h2>
+            <h2>Bedienung</h2>
             <p>
-              Jede gefressene Frucht erhöht deinen Score und steigert die
-              Geschwindigkeit. Nach jedem Spiel wird dein Ergebnis an den Server
-              gesendet, um den Highscore zu aktualisieren.
+              Klicke eine eigene Figur an, um mögliche Züge hervorzuheben, und
+              bestätige den Zielplatz mit einem zweiten Klick. Rochade,
+              en-passant und Umwandlungen werden automatisch gehandhabt.
+              Beende eine Partie per Aufgabe oder Remisangebot über die
+              Schnell-Optionen.
             </p>
-            <button id="reset-button" type="button" class="button">
-              Neu starten
-            </button>
+            <div class="button-group">
+              <button id="reset-button" type="button" class="button">
+                Neue Partie
+              </button>
+              <button id="resign-white" type="button" class="button button--secondary">
+                Weiß gibt auf
+              </button>
+              <button id="resign-black" type="button" class="button button--secondary">
+                Schwarz gibt auf
+              </button>
+              <button id="offer-draw" type="button" class="button button--secondary">
+                Remis
+              </button>
+            </div>
           </section>
         </aside>
       </main>
     </div>
 
-    <script defer src="{{ url_for('static', filename='js/snake.js') }}"></script>
+    <script defer src="{{ url_for('static', filename='js/chess.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the snake-focused Flask endpoint with a chess results scoreboard API and update the landing view
- rebuild the dashboard template and styling to host a responsive chess experience with statistics and controls
- implement a full chess ruleset in the browser, including move validation, promotions, castling, en-passant and server result syncing, and refresh the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3b4aa593883329f69da85c9f36071